### PR TITLE
Add Local Context

### DIFF
--- a/rvgo/evm_test.go
+++ b/rvgo/evm_test.go
@@ -149,13 +149,13 @@ func stepEVM(t *testing.T, env *vm.EVM, wit *fast.StepWitness, addrs *Addresses,
 	snap := env.StateDB.Snapshot()
 
 	if wit.HasPreimage() {
-		input, err := wit.EncodePreimageOracleInput()
+		input, err := wit.EncodePreimageOracleInput(fast.LocalContext{})
 		require.NoError(t, err)
 		ret, leftOverGas, err := env.Call(vm.AccountRef(addrs.Sender), addrs.Oracle, input, startingGas, big.NewInt(0))
 		require.NoError(t, err, "evm must not fail (ret: %x, gas: %d)", ret, startingGas-leftOverGas)
 	}
 
-	input := wit.EncodeStepInput()
+	input := wit.EncodeStepInput(fast.LocalContext{})
 
 	ret, leftOverGas, err := env.Call(vm.AccountRef(addrs.Sender), addrs.RISCV, input, startingGas, big.NewInt(0))
 	require.NoError(t, err, "evm must not fail (ret: %x), at step %d", ret, step)

--- a/rvgo/fast/evm.go
+++ b/rvgo/fast/evm.go
@@ -3,7 +3,8 @@ package fast
 import "github.com/ethereum/go-ethereum/crypto"
 
 var (
-	StepBytes4                      = crypto.Keccak256([]byte("step(bytes,bytes)"))[:4]
+	StepBytes4                      = crypto.Keccak256([]byte("step(bytes,bytes,bytes32)"))[:4]
 	CheatBytes4                     = crypto.Keccak256([]byte("cheat(uint256,bytes32,bytes32,uint256)"))[:4]
+	CheatLocalKeyBytes4             = crypto.Keccak256([]byte("cheatLocalKey(uint256,bytes32,bytes32,uint256,bytes32)"))[:4]
 	LoadKeccak256PreimagePartBytes4 = crypto.Keccak256([]byte("loadKeccak256PreimagePart(uint256,bytes)"))[:4]
 )

--- a/rvgo/slow/vm.go
+++ b/rvgo/slow/vm.go
@@ -3,6 +3,7 @@ package slow
 import (
 	"encoding/binary"
 	"fmt"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 )
@@ -103,8 +104,8 @@ func Step(calldata []byte, po PreimageOracle) (stateHash common.Hash, outErr err
 
 	// TODO: validate abi offset values?
 
-	stateContentOffset := uint8(4 + 32 + 32 + 32)
-	if iszero(eq(b32asBEWord(calldataload(toU64(4+32*2))), shortToU256(stateSize))) {
+	stateContentOffset := uint8(4 + 32 + 32 + 32 + 32)
+	if iszero(eq(b32asBEWord(calldataload(toU64(4+32*3))), shortToU256(stateSize))) {
 		// user-provided state size must match expected state size
 		panic("invalid state size input")
 	}

--- a/rvgo/vm_go_test.go
+++ b/rvgo/vm_go_test.go
@@ -111,7 +111,7 @@ func fullTest(t *testing.T, vmState *fast.VMState, po *testOracle, symbols fast.
 			require.NoError(t, err)
 
 			if runSlow {
-				slowPostHash, err := slow.Step(wit.EncodeStepInput(), po)
+				slowPostHash, err := slow.Step(wit.EncodeStepInput(fast.LocalContext{}), po)
 				require.NoErrorf(t, err, "slow VM err at step %d, PC %08x: %v", i, vmState.PC, err)
 				require.Equal(t, fastStateHash, slowPostHash, "fast post-state must match slow post-state")
 			}

--- a/rvgo/vm_test.go
+++ b/rvgo/vm_test.go
@@ -75,7 +75,7 @@ func runSlowTestSuite(t *testing.T, path string) {
 		require.NoError(t, err)
 
 		// Now run the same in slow mode
-		input := wit.EncodeStepInput()
+		input := wit.EncodeStepInput(fast.LocalContext{})
 		post, err := slow.Step(input, nil)
 		require.NoErrorf(t, err, "slow VM err at step %d, PC %08x: %v", i, vmState.PC, err)
 

--- a/rvsol/src/PreimageOracle.sol
+++ b/rvsol/src/PreimageOracle.sol
@@ -32,6 +32,32 @@ contract PreimageOracle {
         preimageLengths[key] = size;
     }
 
+    function localize(bytes32 _key, bytes32 _localContext) internal view returns (bytes32 localizedKey_) {
+        assembly {
+            // Grab the current free memory pointer to restore later.
+            let ptr := mload(0x40)
+            // Store the local data key and caller next to each other in memory for hashing.
+            mstore(0, _key)
+            mstore(0x20, caller())
+            mstore(0x40, _localContext)
+            // Localize the key with the above `localize` operation.
+            localizedKey_ := or(and(keccak256(0, 0x60), not(shl(248, 0xFF))), shl(248, 1))
+            // Restore the free memory pointer.
+            mstore(0x40, ptr)
+        }
+    }
+
+    // temporary method for localizeation
+    function cheatLocalKey(uint256 partOffset, bytes32 key, bytes32 part, uint256 size, bytes32 localContext) external {
+        // sanity check key is local key using prefix
+        require(uint8(key[0]) == 1, "must be used for local key");
+        
+        bytes32 localizedKey = localize(key, localContext);
+        preimagePartOk[localizedKey][partOffset] = true;
+        preimageParts[localizedKey][partOffset] = part;
+        preimageLengths[localizedKey] = size;
+    }
+
     // loadKeccak256PreimagePart prepares the pre-image to be read by keccak256 key,
     // starting at the given offset, up to 32 bytes (clipped at preimage length, if out of data).
     function loadKeccak256PreimagePart(uint256 _partOffset, bytes calldata _preimage) external {


### PR DESCRIPTION
WIPWIPWIP

Mirror
- https://github.com/ethereum-optimism/optimism/pull/7629
- https://github.com/ethereum-optimism/optimism/pull/8215
```go
/*
Example calldata:
$ cast calldata "step(bytes,bytes,bytes32)" 0x4141 0x4242 0xFF11FF11FF11FF11EE22EE22EE22EE22FF11FF11FF11FF11EE22EE22EE22EE22
0x00 0000000000000000000000000000000000000000000000000000000000000060 // 1st argument starts at 0x60
0x20 00000000000000000000000000000000000000000000000000000000000000a0 // 2nd argument starts at 0xa0
0x40 ff11ff11ff11ff11ee22ee22ee22ee22ff11ff11ff11ff11ee22ee22ee22ee22 // 3rd argument
0x60 0000000000000000000000000000000000000000000000000000000000000002 // bytes length 2
0x80 4141000000000000000000000000000000000000000000000000000000000000
0xa0 0000000000000000000000000000000000000000000000000000000000000002 // bytes length 2
0xc0 4242000000000000000000000000000000000000000000000000000000000000

$ cast calldata "step(bytes,bytes)" 0x4141 0x4242
0x00 0000000000000000000000000000000000000000000000000000000000000040 // 1st argument starts at 0x60
0x20 0000000000000000000000000000000000000000000000000000000000000080 // 2nd argument starts at 0xa0
0x40 0000000000000000000000000000000000000000000000000000000000000002 // bytes length 2
0x60 4141000000000000000000000000000000000000000000000000000000000000
0x80 0000000000000000000000000000000000000000000000000000000000000002 // bytes length 2
0xa0 4242000000000000000000000000000000000000000000000000000000000000
*/
```